### PR TITLE
Allow rendering 'issue' collections

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.0"

--- a/_config.yml
+++ b/_config.yml
@@ -1,15 +1,12 @@
 title: Fiction International
 # change baseurl to "" for serve and "." for build
-baseurl: "."
+baseurl: ""
 url: ""
-markdown: kramdown
-include: [_data]
 
 collections:
   issues:
-    ouput: true
+    output: true
     # sort_by: num
-    permalink: /issues/:name
 
 defaults:
   - scope:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,13 +1,12 @@
 <head>
-
+<meta charset="utf-8">
 <title>
-	{{ site.title }}
-	{% if page.title %}
-		- {{ page.title }}
-	{% endif %}
+  {{ site.title }}
+  {% if page.title %}
+    - {{ page.title }}
+  {% endif %}
 </title>
 
-<meta charset="utf-8">
 <meta name="title=" content="Fiction International">
 <meta name="robots" content="index, follow">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -24,14 +23,16 @@
 <!-- Fonts -->
 <link href="https://fonts.googleapis.com/css?family=Abril+Fatface|Amatic+SC|Josefin+Sans|Lora&display=swap" rel="stylesheet">
 
-<!-- CDNs: jquery, fontawesome, bootstrap -->
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css">
+
+<!-- CDNs: jquery, fontawesome, bootstrap
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 <script async src="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"></script>
+-->
 
 <!-- local links -->
-<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/common-styles.css">
-<script async type="text/javascript" src="{{ site.baseurl }}/assets/js/common-scripts.js"></script>
+<link rel="stylesheet" href="{{'assets/css/common-styles.css' | relative_url }}">
+<script async type="text/javascript" src="{{ 'assets/js/common-scripts.js' | relative_url }}"></script>
 
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,13 +1,9 @@
 <nav class="navbar fixed-top navbar-expand-lg navbar-dark bg-dark" role="navigation">
 	<a id="home-img" class="navbar-brand" href="#">
 		<img
-
-			src="{{ site.baseurl }}/assets/images/fi-logo-white.png"
-
-		{% if page.active!='Home' %}
-			onclick="window.open('{{ site.baseurl }}/index.html', '_self');"
-		{% endif %}
-		width="256px">
+		  src="{{'assets/images/fi-logo-white.png'|relative_url}}"
+		  width="256px"
+		 />
 	</a>
 
 

--- a/_issues/body.md
+++ b/_issues/body.md
@@ -1,9 +1,0 @@
----
-layout: issue
-
-name: Body
-num: 52
-text: body is best
-img: whyisntjekyllreadingthisthen
----
-more stuff

--- a/_issues/issue_1.md
+++ b/_issues/issue_1.md
@@ -1,0 +1,9 @@
+---
+layout: issue
+title: Lorem Ipsum Dolor
+num: 51
+summary: Summary for *issue_1.md*
+---
+
+Lorem ipsum dolor. This is the body of Issue #51.
+Meh.

--- a/_issues/issue_2.md
+++ b/_issues/issue_2.md
@@ -1,0 +1,9 @@
+---
+layout: issue
+title: Body
+num: 52
+summary: "*body is best*"
+---
+
+Lorem ipsum dolor. This is the body of Issue #52.
+Peace Out!

--- a/_issues/issue_3.md
+++ b/_issues/issue_3.md
@@ -1,0 +1,8 @@
+---
+layout: issue
+title: World in Pain
+num: 53
+summary: "**world in pain is not cool!**"
+---
+
+Lorem ipsum dolor. This is the body of Issue #53.

--- a/_issues/no/body.md
+++ b/_issues/no/body.md
@@ -1,9 +1,0 @@
-
-layout: issue
-
-name: Body
-num: 52
-text: body is best
-img: whyisntjekyllreadingthisthen
----
-more stuff

--- a/_issues/no/worldinpain.md
+++ b/_issues/no/worldinpain.md
@@ -1,9 +1,0 @@
-
-layout: issue
-
-name: World in Pain
-num: 51
-text: world in pain is coo
-img: whyareyoureadingthisfuckinjekyll2
----
-more stuff2

--- a/_issues/worldinpain.md
+++ b/_issues/worldinpain.md
@@ -1,9 +1,0 @@
----
-layout: issue
-
-name: World in Pain
-num: 51
-text: world in pain is coo
-img: whyareyoureadingthisfuckinjekyll
----
-more stuff2

--- a/_layouts/issue.html
+++ b/_layouts/issue.html
@@ -1,11 +1,9 @@
 ---
 layout: default
 ---
-<h1>{{ page.num }}</h1>
+<h1>#{{ page.num }}: {{ page.title }}</h1>
 <h2>{{ page.issue_name }}</h2>
-<img src="../assets/images/covers/{{ page.img }}">
-
 <br>
-hello
+Hello
 
 {{ content }}

--- a/catalog.html
+++ b/catalog.html
@@ -2,7 +2,6 @@
 layout: default-layout
 title: Catalog
 active: Catalog
-permalink: catalog
 ---
 
 <!-- 
@@ -19,26 +18,19 @@ issue.html
 -->
 
 <div id="main-section">
-	<h3>Issue Catalog</h3>
+  <h2 style="margin-bottom:35px;padding-bottom:3px;border-bottom:1px solid #ccc">Issue Catalog</h2>
 
-	<div class="row">
-		<div class="col-md-4 col-sm-6">
-			{% for issue in site.issues %}
-				
-				<h2>Issue #{{ issue.num }}</h2>
-
-				<img src="../assets/images/covers/{{ issue.img }}" width="120px">
-
-				<a href="{{ site.url }}{{ site.baseurl }}{{ issue.url }}.html">
-								<h2>{{ issue.name }}</h2>
-
-				</a>
-
-
-				</h2>
-				<p>{{ issue.summary | markdownify }}</p>
-			{% endfor %}
-		</div>
-	</div>
-
+  <div class="row">
+    <div class="col-md-4 col-sm-6">
+      {% for issue in site.issues %}
+        <h3>
+          <a href="{{ issue.url | relative_url }}">
+            Issue #{{ issue.num }}
+          </a>: <span>{{ issue.title }}</span>
+        </h3>
+        <p>{{ issue.summary | markdownify }}</p>
+        <hr/>
+      {% endfor %}
+    </div>
+  </div>
 </div>

--- a/issues/body.md
+++ b/issues/body.md
@@ -1,9 +1,0 @@
-
-layout: issue
-
-issue_name: Body
-num: 52
-summary: body is good
-img: 52.png
----
-more stuff

--- a/issues/worldinpain.md
+++ b/issues/worldinpain.md
@@ -1,9 +1,0 @@
-
-layout: issue
-
-issue_name: World in Pain
-num: 51
-summary: world is in pain ouch
-img: 51.png
----
-more stuff


### PR DESCRIPTION
The primary reason why the links in `/category.html` didn't work was because of an *easy-to-miss* typo in the metadata of your **`issues` collection**.

The secondary bug with why Jekyll doesn't regenerate the site when *served* without a Gemfile is
**a mystery even to me!!**

Some unrelated FYI:
- don't bother having `include: [_data]`. It is pointless as data dir is always read. But the side-effect of the setting is that it overrides default internal setting of `include: [.htaccess]`
- always prefer using `relative_url` and `absolute_url` to simply template logic. Switch to using
`{{ site.baseurl }}` only for large sites with performance issues.